### PR TITLE
Fixed crash when AnonymousPaths is not specified

### DIFF
--- a/src/AadApiGatekeeper/Extensions/AuthProxyMiddleware.cs
+++ b/src/AadApiGatekeeper/Extensions/AuthProxyMiddleware.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Authentication
             _next = next;
             _authProxyOptions = authProxyOptions.Value;
 
-            _anonymousPaths = _authProxyOptions.AnonymousPaths.Split(',').ToList();
+            _anonymousPaths = _authProxyOptions.AnonymousPaths?.Split(',').ToList() ?? new List<string>();
         }
 
         public async Task Invoke(HttpContext context)


### PR DESCRIPTION
fixes #2 : AadApiGatekeeper is unable to start if no AnonymousPaths is provided 